### PR TITLE
Improve cli-command-definer syntax.

### DIFF
--- a/cli/macros.dylan
+++ b/cli/macros.dylan
@@ -13,16 +13,16 @@ define macro cli-root-definer
 end macro;
 
 define macro cli-command-definer
-  { define cli-command ?root:name (?symbols:*)
+  { define cli-command ?symbols:* (?root:name)
       ?definitions:*
     end }
-    => { define cli-command-aux ?root (?symbols)
+    => { define cli-command-aux (?symbols) (?root)
            (?definitions) (?definitions) (?definitions) (?definitions) (?definitions)
          end }
 end macro;
 
 define macro cli-command-aux-definer
-  { define cli-command-aux ?root:name (?symbols)
+  { define cli-command-aux (?symbols) (?root:name)
       (?definitions) (?bindings) (?implementation) (?keywords) (?parameters)
     end }
     => { begin

--- a/examples/cli-dylan/cli-dylan.dylan
+++ b/examples/cli-dylan/cli-dylan.dylan
@@ -118,17 +118,17 @@ define constant $cli = make(<dylan-cli>);
 
 define cli-root $dylan-cli;
 
-define cli-command $dylan-cli (show dylan version)
+define cli-command show dylan version ($dylan-cli)
   implementation
     format-out("%s\n", release-full-name());
 end;
 
-define cli-command $dylan-cli (show dylan copyright)
+define cli-command show dylan copyright ($dylan-cli)
   implementation
     format-out("%s", release-full-copyright());
 end;
 
-define cli-command $dylan-cli (show project)
+define cli-command show project ($dylan-cli)
   simple parameter project :: <string>,
     node-class: <cli-dylan-project>;
   implementation
@@ -145,7 +145,7 @@ define cli-command $dylan-cli (show project)
     end;
 end;
 
-define cli-command $dylan-cli (open)
+define cli-command open ($dylan-cli)
   simple parameter project :: <string>,
     node-class: <cli-dylan-project>;
   implementation
@@ -174,7 +174,7 @@ define cli-command $dylan-cli (open)
     end;
 end;
 
-define cli-command $dylan-cli (close)
+define cli-command close ($dylan-cli)
   simple parameter project :: <string>,
     node-class: <cli-dylan-project>;
   implementation
@@ -185,7 +185,7 @@ define cli-command $dylan-cli (close)
     end;
 end;
 
-define cli-command $dylan-cli (build)
+define cli-command build ($dylan-cli)
   simple parameter project :: <string>,
     node-class: <cli-dylan-project>;
   implementation
@@ -211,7 +211,7 @@ define cli-command $dylan-cli (build)
     end;
 end;
 
-define cli-command $dylan-cli (clean)
+define cli-command clean ($dylan-cli)
   simple parameter project :: <string>,
     node-class: <cli-dylan-project>;
   implementation
@@ -224,7 +224,7 @@ define cli-command $dylan-cli (clean)
     end;
 end;
 
-define cli-command $dylan-cli (report)
+define cli-command report ($dylan-cli)
   simple parameter report :: <symbol>,
     node-class: <cli-report-type>;
   named parameter project :: <string>,

--- a/examples/demo/cli-demo.dylan
+++ b/examples/demo/cli-demo.dylan
@@ -5,13 +5,13 @@ copyright: see accompanying file LICENSE
 
 define cli-root $root;
 
-define cli-command $root (quit)
+define cli-command quit ($root)
   help "Quit the shell";
   implementation
       tty-finish-activity(current-tty());
 end;
 
-define cli-command $root (directory)
+define cli-command directory ($root)
   help "Show information about directory";
   simple parameter directory :: <string>,
     node-class: <cli-file>,
@@ -21,13 +21,13 @@ define cli-command $root (directory)
     format-out("Nothing to show...\n");
 end;
 
-define cli-command $root (show configuration)
+define cli-command show configuration ($root)
   help "Query configuration";
   implementation
     format-out("Nothing to show...\n");
 end;
 
-define cli-command $root (show interface)
+define cli-command show interface ($root)
   help "Query interfaces";
   simple parameter name :: <string>,
     node-class: <cli-oneof>,
@@ -42,7 +42,7 @@ define cli-command $root (show interface)
     format-out("Nothing to show...\n");
 end;
 
-define cli-command $root (show route)
+define cli-command show route ($root)
   help "Query routes";
   named parameter destination :: <symbol>;
   named parameter source :: <symbol>;
@@ -50,7 +50,7 @@ define cli-command $root (show route)
     format-out("Nothing to show...\n src %= dst %= \n", source, destination);
 end;
 
-define cli-command $root (show log)
+define cli-command show log ($root)
   help "Query logs";
   named parameter service :: <string>,
     node-class: <cli-oneof>,
@@ -62,7 +62,7 @@ define cli-command $root (show log)
     format-out("Nothing to show...\n");
 end;
 
-define cli-command $root (configure)
+define cli-command configure ($root)
   help "Modify configuration";
   implementation
     tty-start-activity(current-tty(),
@@ -73,32 +73,32 @@ end;
 
 define cli-root $configure;
 
-define cli-command $configure (diff)
+define cli-command diff ($configure)
   help "Show changes";
   implementation
     format-out("Configuration unchanged.\n");
 end;
 
-define cli-command $configure (set)
+define cli-command set ($configure)
   help "Change a parameter";
   implementation
     format-out("Not implemented...\n");
 end;
 
-define cli-command $configure (show)
+define cli-command show ($configure)
   help "Show configuration";
   implementation
     format-out("Nothing to show...\n");
 end;
 
-define cli-command $configure (remark)
+define cli-command remark ($configure)
   help "Add remark on current config transaction";
   implementation
     format-out("Not implemented...\n");
   simple parameter remark;
 end;
 
-define cli-command $configure (abort)
+define cli-command abort ($configure)
   help "Abort current config transaction";
   implementation
     begin
@@ -107,7 +107,7 @@ define cli-command $configure (abort)
     end;
 end;
 
-define cli-command $configure (commit)
+define cli-command commit ($configure)
   help "Commit current config transaction";
   implementation
     begin

--- a/tests/cli-test.dylan
+++ b/tests/cli-test.dylan
@@ -7,7 +7,7 @@ define cli-root $simple-root;
 
 define variable progress :: <symbol> = #"init";
 
-define cli-command $simple-root (simple one)
+define cli-command simple one ($simple-root)
   simple parameter alpha;
   implementation
     begin
@@ -16,7 +16,7 @@ define cli-command $simple-root (simple one)
     end;
 end;
 
-define cli-command $simple-root (simple two)
+define cli-command simple two ($simple-root)
   named parameter alpha;
   named parameter beta;
   implementation
@@ -27,7 +27,7 @@ define cli-command $simple-root (simple two)
     end;
 end;
 
-define cli-command $simple-root (simple three)
+define cli-command simple three ($simple-root)
   simple parameter alpha;
   simple parameter beta;
   implementation


### PR DESCRIPTION
This makes it "define cli-command _command_ (_root_) which is
more natural and Dylan-like.
