### PR TITLE
Use MMAllocMisc, define prototype on our own.

### DIFF
--- a/tty/tty-unix-helper.c
+++ b/tty/tty-unix-helper.c
@@ -8,11 +8,11 @@
 #include <termios.h>
 #include <unistd.h>
 
-#include <run-time.h>
+extern void *MMAllocMisc(size_t size);
 
 /* allocation wrapper for "struct termios" */
 struct termios *unix_make_termios() {
-  return (struct termios *)primitive_allocate(sizeof(struct termios));
+  return (struct termios *)MMAllocMisc(sizeof(struct termios));
 }
 
 /* enum wrapper for tcsetattr(x, TCSANOW, y) */


### PR DESCRIPTION
Not all backends for Dylan provide run-time.h.
Also, when using MPS, one should use MMAllocMisc for this sort of
data rather than primitive_allocate().
