### PR TITLE
using print-object so that we can have nicer error/help messages just by...

### DIFF
--- a/command-interface/command-interface-library.dylan
+++ b/command-interface/command-interface-library.dylan
@@ -26,6 +26,7 @@ define module command-interface
   use format-out,
     import: { format-out, force-out,
               format-err, force-err };
+  use print;
   use streams,
     import: { force-output };
   use tty;

--- a/command-interface/nodes.dylan
+++ b/command-interface/nodes.dylan
@@ -144,6 +144,10 @@ define class <symbol-node> (<parse-node>)
     init-keyword: symbol:;
 end class;
 
+define method print-object(object :: <symbol-node>, stream :: <stream>) => ();
+  format(stream, "%s", node-symbol(object));
+end method;
+
 define method node-match (node :: <symbol-node>, parser :: <command-parser>, token :: <command-token>)
  => (matched? :: <boolean>);
   starts-with?(as(<string>, node-symbol(node)),
@@ -177,6 +181,10 @@ define open class <command-node> (<symbol-node>)
   /* all simple parameters */
   slot command-simple-parameters :: <list> = #();
 end class;
+
+define method print-object(object :: <command-node>, stream :: <stream>) => ();
+  format(stream, "%s - %s", node-symbol(object), command-help(object));
+end method;
 
 define method node-accept (node :: <command-node>, parser :: <command-parser>, token :: <command-token>)
  => ();


### PR DESCRIPTION
... format-out("%=", some-node)
