### PR TITLE
Refurbish library

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/build-and-deploy-documentation.yml
+++ b/.github/workflows/build-and-deploy-documentation.yml
@@ -1,0 +1,56 @@
+name: Build and deploy documentation
+
+on:
+  push:
+    # all branches
+    paths:
+      - 'documentation/**'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+# https://github.com/JamesIves/github-pages-deploy-action#readme
+permissions:
+    contents: write
+
+# Set DYLAN environment variable to GITHUB_WORKSPACE so packages are
+# installed in ../../_packages relative to documentation's Makefile
+env:
+  DYLAN: ${{ github.workspace }}
+
+jobs:
+
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check links
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make linkcheck
+
+      - name: Build docs with Furo theme
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make html
+
+      - name: Upload html artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: command-interface-html
+          path: documentation/build/html/
+
+      - name: Bypassing Jekyll on GH Pages
+        run: sudo touch documentation/build/html/.nojekyll
+
+      - name: Deploy docs to GH pages
+        uses: JamesIves/github-pages-deploy-action@v4
+        with:
+          folder: documentation/build/html

--- a/.github/workflows/build-and-test-documentation.yml
+++ b/.github/workflows/build-and-test-documentation.yml
@@ -1,0 +1,35 @@
+name: Build and test documentation
+
+on:
+  push:
+    # all branches
+    paths:
+      - 'documentation/**'
+  pull_request:
+    # all branches
+    paths:
+      - 'documentation/**'
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+# Set DYLAN environment variable to GITHUB_WORKSPACE so packages are
+# installed in ../../_packages relative to documentation's Makefile
+env:
+  DYLAN: ${{ github.workspace }}
+
+jobs:
+
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Check links
+        uses: addnab/docker-run-action@v3
+        with:
+          image: ghcr.io/fraya/dylan-docs
+          options: -v ${{ github.workspace }}/documentation:/docs
+          run: make linkcheck

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -1,0 +1,35 @@
+name: Build and test
+
+on:
+  push:
+    # all branches
+  pull_request:
+    # all branches
+
+  # This enables the Run Workflow button on the Actions tab.
+  workflow_dispatch:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Opendylan
+        uses: dylan-lang/install-opendylan@v3
+
+      - name: Download dependencies
+        run: dylan update
+
+      - name: Build tests
+        run: dylan build command-interface-test
+
+      - name: Run tests
+        run: _build/bin/command-interface-test --progress none --report surefire > _build/TEST-command-interface.xml
+
+      - name: Publish Test Report
+        if: success() || failure()
+        uses: mikepenz/action-junit-report@v4
+        with:
+          report_paths: '**/_build/TEST-*.xml'

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,19 @@
-_build
+# backup files
+*~
+*.bak
+.DS_Store
+
+# project file
+*.hdp
+
+# documentation build directory
+build/
+
+# compiler build directory
+_build/
+
+# dylan tool package cache
+_packages/
+
+# package registry folder
+registry/

--- a/README.rst
+++ b/README.rst
@@ -1,33 +1,35 @@
 Command Interface System
 ========================
+[![Build status](https://github.com/dylan-lang/command-interface/actions/workflows/build-and-test.yml/badge.svg)](https://github.com/dylan-lang/command-interface/actions/workflows/build-and-test.yml) [![Documentation](https://github.com/dylan-lang/command-interface/actions/workflows/build-and-deploy-documentation.yml/badge.svg)](https://github.com/dylan-lang/command-interface/actions/workflows/build-and-deploy-documentation.yml)
 
 This is a system for building command-driven interfaces in Dylan.
 
 It can currently be used to declaratively design terminal-based
 command interfaces, commonly called shells or CLIs.
 
-We also strive to implement graphical command interfaces in a
-similar manner to Symbolics Genera, including support for
-full graphical and markup output.
+We also strive to implement graphical command interfaces in a similar
+manner to `Symbolics Genera
+<https://en.wikipedia.org/wiki/Genera_(operating_system)>`_, including
+support for full graphical and markup output.
 
 Compiling
 ---------
 
-All dependencies are in `Open Dylan`_ itself.
+Update library dependencies::
 
-Just build with::
+    dylan update
 
-    $ dylan-compiler -build command-interface
+Build the library, tests and demo with::
 
-There also is a demo::
+    dylan build --all
 
-    $ dylan-compiler -build command-interface-demo
-    $ _build/bin/command-interface-demo
+Run the demo::
 
-As well as some tests::
+    _build/bin/command-interface-demo
 
-    $ dylan-compiler -build command-interface-test
-    $ _build/bin/command-interface-test
+And the tests::
+
+    _build/bin/command-interface-test
 
 Completion in bash
 ------------------
@@ -39,11 +41,9 @@ interactive shell and from the system shell.
 To enable this feature you need to load the shell snippet
 printed by the following command into your shell::
 
-    $ _build/bin/command-interface-demo bashcomplete
+    _build/bin/command-interface-demo bashcomplete
 
 Once you do this you can complete and execute all commands
 that would be available inside the shell.
 
 This feature is automatically available to library users.
-
-.. _Open Dylan: https://github.com/dylan-lang/opendylan

--- a/documentation/Makefile
+++ b/documentation/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/documentation/make.bat
+++ b/documentation/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/documentation/source/conf.py
+++ b/documentation/source/conf.py
@@ -1,0 +1,55 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Path setup --------------------------------------------------------------
+
+# If extensions (or modules to document with autodoc) are in another directory,
+# add these directories to sys.path here. If the directory is relative to the
+# documentation root, use os.path.abspath to make it absolute, like shown here.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath('../../_packages/sphinx-extensions/current/src/sphinxcontrib'))
+
+import dylan.themes as dylan_themes
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+project = 'Command interface'
+copyright = '2024, Ingo Albrecht'
+author = 'Ingo Albrecht'
+release = '0.1.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = [
+    'dylan.domain',
+    'sphinx.ext.intersphinx'
+]
+
+templates_path = ['_templates']
+
+# List of patterns, relative to source directory, that match files and
+# directories to ignore when looking for source files.
+# This pattern also affects html_static_path and html_extra_path.
+exclude_patterns = ['_build']
+
+# This makes it so that each document doesn't have to use
+#   .. default-domain:: dylan
+# but they probably should anyway, so that they can be built separately
+# without depending on this top-level config file.
+primary_domain = 'dylan'
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'furo'
+html_static_path = ['_static']
+
+# Ignore certification verification
+tls_verify = False

--- a/documentation/source/index.rst
+++ b/documentation/source/index.rst
@@ -1,0 +1,23 @@
+Welcome to Command interface's documentation!
+=============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+This is a system for building command-driven interfaces in Dylan.
+
+It can currently be used to declaratively design terminal-based
+command interfaces, commonly called shells or CLIs.
+
+We also strive to implement graphical command interfaces in a similar
+manner to Symbolics Genera, including support for full graphical and
+markup output.
+
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`

--- a/dylan-package.json
+++ b/dylan-package.json
@@ -1,0 +1,16 @@
+{
+    "name": "command-interface",
+    "description": "Interactive command interface system for Dylan",
+    "keywords": [ "command-line" ],
+    "version": "0.1.0",
+    "url": "https://github.com/dylan-lang/command-interface",
+    "category" : "utilities",
+    "contact": "dylan-lang@googlegroups.com",
+    "dependencies": [],
+    "dev-dependencies": [
+	"testworks@3.2.0",
+	"sphinx-extensions@0.2.0"
+    ],
+    "license": "MIT",
+    "license-url": "https://opensource.org/license/mit"
+}

--- a/registry/generic/command-interface
+++ b/registry/generic/command-interface
@@ -1,1 +1,0 @@
-abstract://dylan/command-interface/command-interface.lid

--- a/registry/generic/command-interface-demo
+++ b/registry/generic/command-interface-demo
@@ -1,1 +1,0 @@
-abstract://dylan/examples/demo/command-interface-demo.lid

--- a/registry/generic/command-interface-test
+++ b/registry/generic/command-interface-test
@@ -1,1 +1,0 @@
-abstract://dylan/tests/command-interface-test.lid

--- a/registry/generic/tty
+++ b/registry/generic/tty
@@ -1,1 +1,0 @@
-abstract://dylan/tty/tty.lid


### PR DESCRIPTION
- Update .gitignore (Fix #29)
- Remove registry/ (Fix #25)
- Add package description (Fix #24)
- Add CI build and test (Fix #26)
- Add documentation (skeleton) (Fix #27)
- Update README (Fix #31)
- Add CI to build documentation (Fix #28)

    I have made two GH actions. One is to build and check for link
    errors when a push or a pull request (PR) is made. The other on
    push only.

    If we try to deploy the documentation to GH pages on PR the action
    don't have permissions to write and fails. So I have done
    'build-and-test.yml' so in a PR we can catch any error of broken
    links in the documentation and when the PR is accepted the push
    action will deploy the documentation to GH pages with
    'build-and-deploy-documentation'.